### PR TITLE
fix: not to save postprocessed image into extra folder

### DIFF
--- a/stable_horde.py
+++ b/stable_horde.py
@@ -403,6 +403,7 @@ class StableHorde:
                     extras_upscaler_2_visibility=0.0,
                     gfpgan_visibility=0.0, codeformer_visibility=0.0, codeformer_weight=0.0,
                     image_folder="", input_dir="", output_dir="",
+                    save_output=False,
                 )
 
             image = images[0]


### PR DESCRIPTION
When we migrated to the new `postprocessing` API in #33 , there is a new parameter `save_image` default to `True`, so webui would try to save generations into the `extra` folder which is generally not we want.