### PR TITLE
fix: submit function should aceept only one param

### DIFF
--- a/stable_horde.py
+++ b/stable_horde.py
@@ -613,7 +613,7 @@ class StableHorde:
         self.state.sampler = sampler_name
         self.state.image = image
 
-        res = await job.submit(image, await self.get_session())
+        res = await job.submit(image)
         if res:
             self.state.status = f"Submission accepted, reward {res} received."
 


### PR DESCRIPTION
## Please check the following items before submitting your pull request

<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->

## Description

<!--
Please describe your changes.

If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.

If your pull request changes the UI, please include screenshots of the changes.
-->

Fix an bug that the `submit` function should only accept one parameter.