### PR TITLE
feat: add option to disable settings restore - performance boost

### DIFF
--- a/scripts/script.py
+++ b/scripts/script.py
@@ -26,6 +26,7 @@ def apply_stable_horde_settings(
     allow_painting: bool,
     allow_unsafe_ipaddr: bool,
     allow_post_processing,
+    restore_settings: bool,
     nsfw: bool,
     interval: int,
     max_pixels: str,
@@ -39,6 +40,7 @@ def apply_stable_horde_settings(
     config.allow_painting = allow_painting
     config.allow_unsafe_ipaddr = allow_unsafe_ipaddr
     config.allow_post_processing = allow_post_processing
+    config.restore_settings = restore_settings
     config.interval = interval
     config.endpoint = endpoint
     config.apikey = apikey
@@ -108,6 +110,10 @@ def on_ui_tabs():
                         )
                         allow_post_processing = gr.Checkbox(
                             config.allow_post_processing, label="Allow Post Processing"
+                        )
+                        restore_settings = gr.Checkbox(
+                            config.restore_settings,
+                            label="Restore settings after rendering a job",
                         )
                         nsfw = gr.Checkbox(config.nsfw, label="Allow NSFW")
                         interval = gr.Slider(
@@ -245,6 +251,7 @@ def on_ui_tabs():
                 allow_painting,
                 allow_unsafe_ipaddr,
                 allow_post_processing,
+                restore_settings,
                 nsfw,
                 interval,
                 max_pixels,

--- a/stable_horde/config.py
+++ b/stable_horde/config.py
@@ -11,6 +11,7 @@ class StableHordeConfig(object):
     interval: int = 10
     max_pixels: int = 1048576  # 1024x1024
     nsfw: bool = False
+    restore_settings: bool = True
     allow_img2img: bool = True
     allow_painting: bool = True
     allow_unsafe_ipaddr: bool = True
@@ -47,6 +48,7 @@ class StableHordeConfig(object):
                 "allow_painting": True,
                 "allow_unsafe_ipaddr": True,
                 "allow_post_processing": True,
+                "restore_settings": True,
                 "show_image_preview": False,
                 "save_images": False,
                 "save_images_folder": "horde",

--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -312,6 +312,7 @@ class StableHorde:
             "override_settings": {
                 "sd_model_checkpoint": local_model,
             },
+            "restore_settings": self.config.restore_settings,
         }
 
         if job.source_image is not None:


### PR DESCRIPTION
## Description

Adds an option to disable restoring settings after each render. This massively increases the performance by not loading two models for each render request. By also enabling model caching, the speed for rendering different models is dramatically increased.

This obviously is a worker only mode where no users actively use the web ui. As my machine otherwise more or less idles during my workday, I disabled the worker when I wanted to render images myself. With this feature I can simply increase the time between jobs and enable the restore option.

This fits into #17 

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [ ] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- code style changes, refactoring, etc. -->
- [ ] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [ ] Other <!-- please specify in the description below -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
