### PR TITLE
fix: model reported as unknown when present but hash not yet calculated.

### DIFF
--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -292,6 +292,8 @@ class StableHorde:
         for checkpoint in sd_models.checkpoints_list.values():
             checkpoint: sd_models.CheckpointInfo
             if checkpoint.name == local_model:
+                if not checkpoint.shorthash:
+                    checkpoint.calculate_shorthash()
                 local_model_shorthash = checkpoint.shorthash
                 break
         if local_model_shorthash is None:


### PR DESCRIPTION
## Description

<!--
Please describe your changes. But now write them in here wrapped in a comment.
If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.
If your pull request changes the UI, please include screenshots of the changes.
-->

I wanted to create a new worker and copied the extensions configuration. When enabling the new worker it always reported `ERROR: Unknown model` for all the models.

I found out that the sd web ui had not yet calculated all the hashes as it was a completely new and empty instance. No models except the default had been loaded. This change forces the models to have their sha hash calculated when being loaded as part of a horde job.

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- code style changes, refactoring, etc. -->
- [ ] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [ ] Other <!-- please specify in the description below -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
