### PR TITLE
Fixed AttributeError: module 'gradio.utils' has no attribute 'synchro…

### DIFF
--- a/scripts/script.py
+++ b/scripts/script.py
@@ -13,9 +13,10 @@ horde = StableHorde(basedir, config)
 
 
 def on_app_started(demo: Optional[gr.Blocks], app: FastAPI):
-    import gradio.utils
+    import asyncio
 
-    gradio.utils.synchronize_async(horde.run)
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(horde.run())
 
 
 def apply_stable_horde_settings(


### PR DESCRIPTION
Fixed AttributeError: module 'gradio.utils' has no attribute 'synchronize_async'

## Description


Fixed [Bug]: #95. The newest gradio library seems to have removed synchronize_async. This can be fixed by importing the 'asyncio' library, and running the 'horde.run()' asynchronous function using the 'run_until_complete' method of the event loop.


## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->


## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
