### PR TITLE
fix: referecing StableDiffusionProcessingTxt2Img error, close #103

### DIFF
--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -18,8 +18,6 @@ from modules.images import save_image
 from modules import (
     shared,
     call_queue,
-    txt2img,
-    img2img,
     processing,
     sd_models,
     sd_samplers,
@@ -344,13 +342,13 @@ class StableHorde:
             )
 
         if job.source_image is not None:
-            p = img2img.StableDiffusionProcessingImg2Img(
+            p = processing.StableDiffusionProcessingImg2Img(
                 init_images=[job.source_image],
                 mask=job.source_mask,
                 **params,
             )
         else:
-            p = txt2img.StableDiffusionProcessingTxt2Img(**params)
+            p = processing.StableDiffusionProcessingTxt2Img(**params)
 
         with call_queue.queue_lock:
             shared.state.begin()


### PR DESCRIPTION
## Description

<!--
Please describe your changes. But now write them in here wrapped in a comment.
If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.
If your pull request changes the UI, please include screenshots of the changes.
-->
close #103
## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
