### PR TITLE
Switch from md5 to sha256

### DIFF
--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -38,6 +38,11 @@ def get_md5sum(filepath):
     with open(filepath, "rb") as f:
         return hashlib.md5(f.read()).hexdigest()
 
+def get_sha256sum(filepath):
+    import hashlib
+
+    with open(filepath, "rb") as f:
+        return hashlib.sha256(f.read()).hexdigest()
 
 class State:
     def __init__(self):
@@ -114,10 +119,10 @@ class StableHorde:
         if checkpoint_info is None:
             return f"Model checkpoint {model_checkpoint} not found"
 
-        local_hash = get_md5sum(checkpoint_info.filename)
+        local_hash = get_sha256sum(checkpoint_info.filename)
         for model in self.supported_models:
             try:
-                remote_hash = model["config"]["files"][0]["md5sum"]
+                remote_hash = model["config"]["files"][0]["sha256sum"]
             except KeyError:
                 continue
 
@@ -133,33 +138,33 @@ class StableHorde:
         self.current_models = {
             k: v for k, v in self.current_models.items() if v in model_names
         }
-        # get the md5sum of all supported models
+        # get the sha256 of all supported models
         for model in self.supported_models:
             try:
-                remote_hashes[model["config"]["files"][0]["md5sum"]] = model["name"]
+                remote_hashes[model["config"]["files"][0]["sha256sum"]] = model["name"]
             except KeyError:
                 continue
 
-        # get the md5sum of all local models and compare it to the remote hashes
-        # if the md5sum matches, add the model to the current models list
+        # get the sha256 of all local models and compare it to the remote hashes
+        # if the sha256 matches, add the model to the current models list
         for checkpoint in sd_models.checkpoints_list.values():
             checkpoint: sd_models.CheckpointInfo
             if checkpoint.name in model_names:
-                # skip expensive md5sum calc if the model is
+                # skip expensive sha256 calc if the model is
                 # already in the current models list
                 if checkpoint.name in self.config.current_models.values():
                     continue
-                print(f"Calculating md5sum for {checkpoint.name}")
-                local_hash = get_md5sum(checkpoint.filename)
+                print(f"Calculating sha256 for {checkpoint.name}")
+                local_hash = get_sha256sum(checkpoint.filename)
                 if local_hash in remote_hashes:
                     self.current_models[remote_hashes[local_hash]] = checkpoint.name
                     print(
-                        f"md5sum for {checkpoint.name} is {local_hash} \
+                        f"sha256 for {checkpoint.name} is {local_hash} \
                             and it's supported by StableHorde"
                     )
                 else:
                     print(
-                        f"md5sum for {checkpoint.name} is {local_hash} \
+                        f"sha256 for {checkpoint.name} is {local_hash} \
                             but it's not supported by StableHorde"
                     )
 

--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -38,11 +38,13 @@ def get_md5sum(filepath):
     with open(filepath, "rb") as f:
         return hashlib.md5(f.read()).hexdigest()
 
+
 def get_sha256sum(filepath):
     import hashlib
 
     with open(filepath, "rb") as f:
         return hashlib.sha256(f.read()).hexdigest()
+
 
 class State:
     def __init__(self):


### PR DESCRIPTION
## Description

Some newer StableHorde models are being added with only a sha256, not an md5.

I checked and was not able to find any models with only an md5, so it seems safe to switch completely rather than trying to implement both.

While I believe this leaves the old `get_md5sum()` function unused, I decided to leave the code there just in case.

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->
- [x] Feature <!-- non-breaking change which adds functionality -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
