### PR TITLE
Execute in a separate thread

### DIFF
--- a/scripts/script.py
+++ b/scripts/script.py
@@ -2,8 +2,9 @@ from typing import Optional
 
 from fastapi import FastAPI
 import gradio as gr
-from gradio.utils import run_coro_in_background
+import asyncio
 import requests
+from threading import Thread
 
 from modules import scripts, script_callbacks, sd_models, shared
 
@@ -15,8 +16,6 @@ horde = StableHorde(basedir, config)
 
 
 def on_app_started(demo: Optional[gr.Blocks], app: FastAPI):
-    import asyncio
-
     started = False
 
     @app.on_event("startup")
@@ -24,7 +23,8 @@ def on_app_started(demo: Optional[gr.Blocks], app: FastAPI):
     async def startup_event():
         nonlocal started
         if not started:
-            run_coro_in_background(horde.run)
+            thread = Thread(daemon=True, target=horde_thread)
+            thread.start()
             started = True
 
     # This is a hack to make sure the startup event is called even it is not in an async scope
@@ -34,6 +34,10 @@ def on_app_started(demo: Optional[gr.Blocks], app: FastAPI):
     else:
         local_url = demo.local_url
     requests.get(f"{local_url}horde/startup-events")
+
+
+def horde_thread():
+    asyncio.run(horde.run())
 
 
 def apply_stable_horde_settings(


### PR DESCRIPTION
## Description

The changes in 9edcf3bb7048115292107aba3e1e4ae18e1a25b7, at least for my setup (Conda, Python 3.10, Win10) resulted in horde.run() running async, but still in the main thread. This mostly worked, but caused the whole WebUI to block while horde.run() wasn't sleeping.

I tried a couple of things, and this is what ended up working best for me, with a lot of the functions in the loop being async and it not being possible to use await in a non-async function. Moving the thread function somewhere else might be more elegant, I don't know your code well enough to know where would be best to put it though.

<!--
Please describe your changes. But now write them in here wrapped in a comment.
If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.
If your pull request changes the UI, please include screenshots of the changes.
-->

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .` (The file has issues, but they're not my fault.)
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
