### PR TITLE
Check the contents of has_nsfw_concept in addition to the existence.

### DIFF
--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -485,7 +485,7 @@ class StableHorde:
             images=x_image, clip_input=safety_checker_input.pixel_values
         )
 
-        if has_nsfw_concept:
+        if has_nsfw_concept and any(has_nsfw_concept):
             return self.sfw_request_censor, has_nsfw_concept
         return Image.fromarray(image), has_nsfw_concept
 


### PR DESCRIPTION
## Description

It turns out safety_checker() returns an array of booleans rather than a boolean, which was causing the NSFW check to always be true.

In testing, the array was length 1. However, [people who know more than me](https://github.com/huggingface/diffusers/blob/174dcd697faf88370f1e7b2eeabb059dd8f1b2f4/src/diffusers/pipelines/stable_diffusion/pipeline_stable_diffusion.py#L764C77-L764C77) iterate over the array rather than assuming it's always length 1, so I've done the same here.

Fixes #91. However, in testing I did find that even with "Allow NSFW" unchecked in the UI, it will still sometimes get jobs with job.nsfw_censor = False. Because of that the discussion there about using the blacklist and possibly exposing it in the UI is still valid, so I'm not sure if you want to close it or not.

I did a brief investigation into the cause and it seems to be on StableHorde's end; despite "nsfw" being False in the job poll, occasionally it's returning payloads with NSFW jobs anyhow. It shouldn't be too difficult to add a check and reject jobs not matching the current setting, but that's beyond the scope of this PR.

<!--
Please describe your changes. But now write them in here wrapped in a comment.
If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.
If your pull request changes the UI, please include screenshots of the changes.
-->

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [x] Bugfix <!-- non-breaking change which fixes an issue -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [x] I've checked that this isn't a duplicate pull request.
- [x] I've tested my changes with the latest SD-Webui version.
- [x] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [x] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .` (The errors there are unrelated to this PR.)
- [x] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [x] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
