### PR TITLE
Model link update and hash fix

### DIFF
--- a/scripts/script.py
+++ b/scripts/script.py
@@ -187,8 +187,7 @@ def on_ui_tabs():
                             value=[
                                 model.name
                                 for model in sd_models.checkpoints_list.values()
-                                if model.name
-                                in list(config.current_models.values())
+                                if model.name in list(config.current_models.values())
                             ],
                             label="Selected models for sharing",
                             elem_id=tab_prefix + "local-selected-models",
@@ -209,9 +208,7 @@ def on_ui_tabs():
                     show_images = gr.Checkbox(
                         config.show_image_preview, label="Show Images"
                     )
-                    save_images = gr.Checkbox(
-                        config.save_images, label="Save Images"
-                    )
+                    save_images = gr.Checkbox(config.save_images, label="Save Images")
 
                     refresh = gr.Button(
                         "Refresh",
@@ -237,9 +234,7 @@ def on_ui_tabs():
                         readonly=True,
                     ).style(grid=4)
 
-                    def on_refresh(
-                        image=False, show_images=config.show_image_preview
-                    ):
+                    def on_refresh(image=False, show_images=config.show_image_preview):
                         cid = f"Current ID: {horde.state.id}"
                         html = "".join(
                             map(
@@ -248,9 +243,7 @@ def on_ui_tabs():
                             )
                         )
                         images = (
-                            [horde.state.image]
-                            if horde.state.image is not None
-                            else []
+                            [horde.state.image] if horde.state.image is not None else []
                         )
                         if image and show_images:
                             return cid, html, horde.state.status, images

--- a/scripts/script.py
+++ b/scripts/script.py
@@ -31,6 +31,7 @@ def on_app_started(demo: Optional[gr.Blocks], app: FastAPI):
     # called even it is not in an async scope
     # fix https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/issues/109
     if demo is None:
+        # flake8: noqa: E501
         local_url = f"http://localhost:{shared.cmd_opts.port if shared.cmd_opts.port else 7861}/"
     else:
         local_url = demo.local_url
@@ -187,7 +188,8 @@ def on_ui_tabs():
                             value=[
                                 model.name
                                 for model in sd_models.checkpoints_list.values()
-                                if model.name in list(config.current_models.values())
+                                if model.name
+                                in list(config.current_models.values())
                             ],
                             label="Selected models for sharing",
                             elem_id=tab_prefix + "local-selected-models",
@@ -208,7 +210,9 @@ def on_ui_tabs():
                     show_images = gr.Checkbox(
                         config.show_image_preview, label="Show Images"
                     )
-                    save_images = gr.Checkbox(config.save_images, label="Save Images")
+                    save_images = gr.Checkbox(
+                        config.save_images, label="Save Images"
+                    )
 
                     refresh = gr.Button(
                         "Refresh",
@@ -234,7 +238,9 @@ def on_ui_tabs():
                         readonly=True,
                     ).style(grid=4)
 
-                    def on_refresh(image=False, show_images=config.show_image_preview):
+                    def on_refresh(
+                        image=False, show_images=config.show_image_preview
+                    ):
                         cid = f"Current ID: {horde.state.id}"
                         html = "".join(
                             map(
@@ -243,7 +249,9 @@ def on_ui_tabs():
                             )
                         )
                         images = (
-                            [horde.state.image] if horde.state.image is not None else []
+                            [horde.state.image]
+                            if horde.state.image is not None
+                            else []
                         )
                         if image and show_images:
                             return cid, html, horde.state.status, images

--- a/scripts/script.py
+++ b/scripts/script.py
@@ -188,8 +188,7 @@ def on_ui_tabs():
                             value=[
                                 model.name
                                 for model in sd_models.checkpoints_list.values()
-                                if model.name
-                                in list(config.current_models.values())
+                                if model.name in list(config.current_models.values())
                             ],
                             label="Selected models for sharing",
                             elem_id=tab_prefix + "local-selected-models",
@@ -210,9 +209,7 @@ def on_ui_tabs():
                     show_images = gr.Checkbox(
                         config.show_image_preview, label="Show Images"
                     )
-                    save_images = gr.Checkbox(
-                        config.save_images, label="Save Images"
-                    )
+                    save_images = gr.Checkbox(config.save_images, label="Save Images")
 
                     refresh = gr.Button(
                         "Refresh",
@@ -238,9 +235,7 @@ def on_ui_tabs():
                         readonly=True,
                     ).style(grid=4)
 
-                    def on_refresh(
-                        image=False, show_images=config.show_image_preview
-                    ):
+                    def on_refresh(image=False, show_images=config.show_image_preview):
                         cid = f"Current ID: {horde.state.id}"
                         html = "".join(
                             map(
@@ -249,9 +244,7 @@ def on_ui_tabs():
                             )
                         )
                         images = (
-                            [horde.state.image]
-                            if horde.state.image is not None
-                            else []
+                            [horde.state.image] if horde.state.image is not None else []
                         )
                         if image and show_images:
                             return cid, html, horde.state.status, images

--- a/scripts/script.py
+++ b/scripts/script.py
@@ -27,7 +27,8 @@ def on_app_started(demo: Optional[gr.Blocks], app: FastAPI):
             run_coro_in_background(horde.run)
             started = True
 
-    # This is a hack to make sure the startup event is called even it is not in an async scope
+    # This is a hack to make sure the startup event is
+    # called even it is not in an async scope
     # fix https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/issues/109
     if demo is None:
         local_url = f"http://localhost:{shared.cmd_opts.port if shared.cmd_opts.port else 7861}/"
@@ -124,10 +125,12 @@ def on_ui_tabs():
                             config.allow_painting, label="Allow Painting"
                         )
                         allow_unsafe_ipaddr = gr.Checkbox(
-                            config.allow_unsafe_ipaddr, label="Allow Unsafe IP Address"
+                            config.allow_unsafe_ipaddr,
+                            label="Allow Unsafe IP Address",
                         )
                         allow_post_processing = gr.Checkbox(
-                            config.allow_post_processing, label="Allow Post Processing"
+                            config.allow_post_processing,
+                            label="Allow Post Processing",
                         )
                         restore_settings = gr.Checkbox(
                             config.restore_settings,
@@ -184,7 +187,8 @@ def on_ui_tabs():
                             value=[
                                 model.name
                                 for model in sd_models.checkpoints_list.values()
-                                if model.name in list(config.current_models.values())
+                                if model.name
+                                in list(config.current_models.values())
                             ],
                             label="Selected models for sharing",
                             elem_id=tab_prefix + "local-selected-models",
@@ -205,10 +209,14 @@ def on_ui_tabs():
                     show_images = gr.Checkbox(
                         config.show_image_preview, label="Show Images"
                     )
-                    save_images = gr.Checkbox(config.save_images, label="Save Images")
+                    save_images = gr.Checkbox(
+                        config.save_images, label="Save Images"
+                    )
 
                     refresh = gr.Button(
-                        "Refresh", visible=False, elem_id=tab_prefix + "refresh"
+                        "Refresh",
+                        visible=False,
+                        elem_id=tab_prefix + "refresh",
                     )
                     refresh_image = gr.Button(
                         "Refresh Image",
@@ -229,7 +237,9 @@ def on_ui_tabs():
                         readonly=True,
                     ).style(grid=4)
 
-                    def on_refresh(image=False, show_images=config.show_image_preview):
+                    def on_refresh(
+                        image=False, show_images=config.show_image_preview
+                    ):
                         cid = f"Current ID: {horde.state.id}"
                         html = "".join(
                             map(
@@ -238,7 +248,9 @@ def on_ui_tabs():
                             )
                         )
                         images = (
-                            [horde.state.image] if horde.state.image is not None else []
+                            [horde.state.image]
+                            if horde.state.image is not None
+                            else []
                         )
                         if image and show_images:
                             return cid, html, horde.state.status, images

--- a/stable_horde/horde.py
+++ b/stable_horde/horde.py
@@ -25,8 +25,8 @@ from modules import (
     sd_samplers,
 )
 
-stable_horde_supported_models_url = "https://raw.githubusercontent.com/Haidra-Org/\
-    AI-Horde-image-model-reference/main/stable_diffusion.json"
+# flake8: noqa: E501
+stable_horde_supported_models_url = "https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json"
 
 safety_model_id = "CompVis/stable-diffusion-safety-checker"
 safety_feature_extractor = None
@@ -86,9 +86,7 @@ class StableHorde:
         self.session: Optional[aiohttp.ClientSession] = None
 
         self.sfw_request_censor = Image.open(
-            path.join(
-                self.config.basedir, "assets", "nsfw_censor_sfw_request.png"
-            )
+            path.join(self.config.basedir, "assets", "nsfw_censor_sfw_request.png")
         )
 
         self.supported_models = []
@@ -102,9 +100,7 @@ class StableHorde:
             attempts -= 1
             async with aiohttp.ClientSession() as session:
                 try:
-                    async with session.get(
-                        stable_horde_supported_models_url
-                    ) as resp:
+                    async with session.get(stable_horde_supported_models_url) as resp:
                         if resp.status != 200:
                             raise aiohttp.ClientError()
                         data = await resp.text()
@@ -122,9 +118,7 @@ class StableHorde:
 
     def detect_current_model(self):
         model_checkpoint = shared.opts.sd_model_checkpoint
-        checkpoint_info = sd_models.checkpoints_list.get(
-            model_checkpoint, None
-        )
+        checkpoint_info = sd_models.checkpoints_list.get(model_checkpoint, None)
         if checkpoint_info is None:
             return f"Model checkpoint {model_checkpoint} not found"
 
@@ -149,9 +143,7 @@ class StableHorde:
         # get the sha256 of all supported models
         for model in self.supported_models:
             try:
-                remote_hashes[
-                    model["config"]["files"][0]["sha256sum"]
-                ] = model["name"]
+                remote_hashes[model["config"]["files"][0]["sha256sum"]] = model["name"]
             except KeyError:
                 continue
         # get the sha256 of all local models and compare it to the remote hashes
@@ -170,9 +162,7 @@ class StableHorde:
                     continue
 
                 if local_hash in remote_hashes:
-                    self.current_models[
-                        remote_hashes[local_hash]
-                    ] = checkpoint.name
+                    self.current_models[remote_hashes[local_hash]] = checkpoint.name
                     print(
                         f"sha256 for {checkpoint.name} is {local_hash} \
                             and it's supported by StableHorde"
@@ -402,12 +392,8 @@ class StableHorde:
         if not has_nsfw and (
             "GFPGAN" in postprocessors or "CodeFormers" in postprocessors
         ):
-            model = (
-                "CodeFormer" if "CodeFormers" in postprocessors else "GFPGAN"
-            )
-            face_restorators = [
-                x for x in shared.face_restorers if x.name() == model
-            ]
+            model = "CodeFormer" if "CodeFormers" in postprocessors else "GFPGAN"
+            face_restorators = [x for x in shared.face_restorers if x.name() == model]
             if len(face_restorators) == 0:
                 print(f"ERROR: No face restorer for {model}")
 
@@ -506,9 +492,7 @@ class StableHorde:
                 safety_model_id
             )
 
-        safety_checker_input = safety_feature_extractor(
-            x_image, return_tensors="pt"
-        )
+        safety_checker_input = safety_feature_extractor(x_image, return_tensors="pt")
         image, has_nsfw_concept = safety_checker(
             images=x_image, clip_input=safety_checker_input.pixel_values
         )
@@ -523,9 +507,7 @@ class StableHorde:
                 "apikey": self.config.apikey,
                 "Content-Type": "application/json",
             }
-            self.session = aiohttp.ClientSession(
-                self.config.endpoint, headers=headers
-            )
+            self.session = aiohttp.ClientSession(self.config.endpoint, headers=headers)
         # check if apikey has changed
         elif self.session.headers["apikey"] != self.config.apikey:
             await self.session.close()
@@ -537,9 +519,7 @@ class StableHorde:
         if status == 401:
             self.state.status = "ERROR: Invalid API Key"
         elif status == 403:
-            self.state.status = (
-                f"ERROR: Access Denied. ({res.get('message', '')})"
-            )
+            self.state.status = f"ERROR: Access Denied. ({res.get('message', '')})"
         elif status == 404:
             self.state.status = "ERROR: Request Not Found"
         else:


### PR DESCRIPTION
## Description
close #77 
- Made sha265 calculations use stable hordes own module.
- added original supported models (https://raw.githubusercontent.com/Haidra-Org/AI-Horde-image-model-reference/main/stable_diffusion.json) after discussion with their lead programmer on discord
- minor: fixed session key change after ui api key change
When I use the new dreamshaper model from civit ai as specified in the model json, everything works fine. (https://civitai.com/api/download/models/78164?type=Model&format=SafeTensor&size=full&fp=fp16)
<!--
Please describe your changes. But now write them in here wrapped in a comment.
If your pull request fixes an issue, please reference the issue number as "close #000" in the pull request description.
If your pull request changes the UI, please include screenshots of the changes.
-->

## Type of changes

<!-- Please select the type of change(s) made in this pull request, and delete inrelavant ones -->

- [X] Bugfix <!-- non-breaking change which fixes an issue -->
- [ ] Feature <!-- non-breaking change which adds functionality -->
- [ ] Refactoring <!-- code style changes, refactoring, etc. -->
- [X] Optimization <!-- code performance improvements, etc. -->
- [ ] Documentation <!-- changes to documentation only -->
- [ ] CI/CD <!-- changes to CI/CD pipeline -->
- [ ] Other <!-- please specify in the description below -->

## Please check the following items before submitting your pull request
<!-- Thank you for contributing to the SD-WebUI Stable Horde Worker Bridge Project!
Please check the following items before submitting your pull request.

Note: You can install flake8 and black that we are using for linting the code with `pip install -r requirements.txt` -->

- [X] I've checked that this isn't a duplicate pull request.
- [X] I've tested my changes with the latest SD-Webui version.
- [X] I've format my code with [black](https://black.readthedocs.io/): `black .`
- [X] I've lint my code with [flake8](https://flake8.pycqa.org/): `flake8 .`
**Note**: there are changes which cant be linted that were in the code even before my PR.
- [X] I've read the [Contribution Guidelines](https://github.com/sdwebui-w-horde/sd-webui-stable-horde-worker/blob/master/CONTRIBUTING.md)
- [X] I've read the [Code of Conduct](https://github.com/sdwebui-w-horde/.github/blob/master/CODE_OF_CONDUCT.md)
